### PR TITLE
Add DataHub demo with dlt pipeline integration

### DIFF
--- a/datahub-demo/README.md
+++ b/datahub-demo/README.md
@@ -1,0 +1,267 @@
+# dlt + DataHub demo
+
+A minimal end-to-end demo: a `dlt` pipeline pulls data from the GitHub REST API into DuckDB, then publishes its datasets, schemas, and lineage to a locally-running DataHub instance.
+
+The goal is to showcase the DataHub features that work naturally with a `dlt` pipeline — cataloging, containers, lineage, schema tracking, run history, ownership, and tags.
+
+---
+
+## What you'll see at the end
+
+- `repos` and `issues` tables loaded into DuckDB from the GitHub API.
+- Both tables (and dlt's internal `_dlt_loads` / `_dlt_pipeline_state`) catalogued in DataHub with full schemas.
+- A pipeline **container** in DataHub grouping the tables.
+- A **lineage** graph: `GitHub API → dlt pipeline → DuckDB tables`.
+- Each pipeline run recorded as an **operation** event (success/fail, row counts).
+
+---
+
+## Prerequisites
+
+| Tool | Why | Install |
+| --- | --- | --- |
+| Docker Desktop | Runs the local DataHub stack (GMS, MySQL, Elasticsearch, Kafka, UI) | https://www.docker.com/products/docker-desktop |
+| Python **3.11** | DataHub CLI prints a warning above 3.11; stay on 3.11 to avoid surprises | `brew install python@3.11` |
+| `uv` | Project / dependency manager | `brew install uv` |
+| GitHub PAT | Auth for the GitHub REST API (any classic token with `public_repo` is fine) | https://github.com/settings/tokens |
+
+Make sure Docker Desktop is **running** and has at least **8 GB RAM** allocated (Settings → Resources). The DataHub quickstart is a heavy stack.
+
+If your venv is on Python 3.13+, you'll see `Python versions above 3.11 are not actively tested with yet` from the `datahub` CLI. To pin 3.11:
+
+```bash
+uv venv --python 3.11
+uv pip install -r requirements.txt
+```
+
+---
+
+## Step 1 — Clone and create the virtualenv
+
+```bash
+git clone <this-repo>
+cd datahub
+uv venv --python 3.11
+```
+
+You don't need to `source .venv/bin/activate` — every command below uses `uv run`, which picks up the venv automatically.
+
+## Step 2 — Install Python dependencies
+
+```bash
+uv pip install -r requirements.txt
+uv pip install "acryl-datahub[datahub-rest]"
+```
+
+`acryl-datahub` ships both the `datahub` CLI (used to launch the local stack) and the Python SDK v2 (`datahub.sdk.DataHubClient` + `LineageClient`) used by `dlt_to_datahub.py` to emit metadata.
+
+## Step 3 — Launch DataHub locally
+
+Make sure Docker Desktop is **running** before this step (the quickstart talks to the local Docker daemon).
+
+```bash
+uv run datahub docker quickstart
+```
+
+First run pulls ~5 GB of images and takes 5–10 minutes. When it finishes you'll have:
+
+| Service | URL | Purpose |
+| --- | --- | --- |
+| DataHub UI | http://localhost:9002 | Browser UI (login: `datahub` / `datahub`) |
+| GMS | http://localhost:8080 | Metadata service — what the pipeline emits to |
+
+Sanity check:
+
+```bash
+curl http://localhost:8080/health   # should return "GOOD"
+```
+
+To stop / reset later:
+
+```bash
+uv run datahub docker quickstart --stop   # stop, keep data
+uv run datahub docker nuke                # wipe everything
+```
+
+## Step 4 — Configure the GitHub token
+
+The dlt CLI already created `.dlt/secrets.toml`. Put your PAT there:
+
+```toml
+# .dlt/secrets.toml
+[sources]
+access_token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+`.dlt/` is gitignored, so this won't be committed.
+
+## Step 5 — Run the pipeline
+
+```bash
+uv run python rest_api_pipeline.py
+```
+
+What happens, in order:
+
+1. dlt pulls `repos` + `issues` from the GitHub API into DuckDB (`github_pipeline.duckdb`).
+2. `dlt_to_datahub.integrate_dlt_pipeline_with_datahub()` connects to GMS (`localhost:8080`) using `DataHubClient`, then for each loaded table:
+   - Upserts a `Container` (one per pipeline dataset)
+   - Upserts a `Dataset` with schema + columns (typed)
+   - Calls `client.lineage.add_lineage(upstream=<github URN>, downstream=<duckdb URN>)`
+3. The script prints the container URL plus each lineage edge it emitted.
+
+Verify in DuckDB:
+
+```bash
+uv run python -c "import duckdb; con = duckdb.connect('github_pipeline.duckdb'); print(con.sql('SHOW ALL TABLES'))"
+```
+
+## Step 6 — Explore in DataHub
+
+Open http://localhost:9002 and walk through:
+
+**Auto-emitted by the pipeline:**
+
+1. **Search** — type `repos` or `issues`. Tables (and child tables like `repos__topics`) show up.
+2. **Container** — `github_data` groups every loaded table under one pipeline run.
+3. **Schema tab** — typed columns extracted from dlt's inferred schema.
+4. **Lineage tab** — *Upstreams* shows `dlt-hub/repos` (GitHub) → `repos` (DuckDB). *Downstreams* shows the parent → child chain (`repos → repos__topics`). Toggle `direct` / `indirect` to expand the graph.
+5. **Documentation** — every dataset has a default `Loaded by dlt pipeline ...` description.
+6. **Tags** — every dataset is tagged `dlt-ingested`. Search `tag:dlt-ingested` to filter.
+7. **Search by tag** — top-bar filter `tags = dlt-ingested` to see everything dlt loaded across all pipelines.
+
+**Manually set in the UI (the governance demo):**
+
+8. **Owners** — open `github_data.repos` → click `+` next to Owners → assign yourself.
+9. **Domain** — assign a domain like `Source Systems`.
+10. **Glossary terms** — open `issues` schema → tag `user.email` with a `PII` glossary term.
+11. **Long-form docs** — write a richer Markdown description in the *Documentation* tab.
+
+**Re-run for run history:**
+
+12. `uv run python rest_api_pipeline.py` again. Each run shows up under the dataset's *Stats / Operations* view with timestamp + row counts.
+
+---
+
+## Demo talking points (DataHub features that pair with dlt)
+
+| Feature | What dlt provides | What DataHub adds |
+| --- | --- | --- |
+| Cataloging | Loaded tables + JSON schemas | Searchable, browsable inventory across all sources |
+| Containers | Pipeline name + dataset name | Visual grouping, navigable as one unit |
+| Lineage | `load_info` (source URL → tables) | Cross-pipeline graph, click-through navigation |
+| Schema evolution | Schema inferred each run | Versioned schema history, diff view |
+| Run history | `load_info` per run | Operation timeline, success/fail trends |
+| Governance | — | Tags, glossary terms, PII classification, ownership |
+| Quality | — | Assertions (freshness, row counts, null rates) |
+| Documentation | — | Markdown descriptions on tables and columns |
+
+Features that exist in DataHub but **aren't relevant to this demo** (mention only if asked): ML features/models, BI dashboard lineage, fine-grained access policies (DuckDB is a local file — only meaningful with Snowflake / BigQuery / MotherDuck).
+
+---
+
+## Auto-emitted vs. manually-curated metadata
+
+DataHub treats catalog metadata in two layers, and the demo deliberately covers both. Knowing the split is the heart of the talk track.
+
+| Field | Set by | Why |
+| --- | --- | --- |
+| Schema (columns, types) | `dlt_to_datahub.py` (auto) | Inferred by dlt during load — emitting it costs nothing |
+| Container | `dlt_to_datahub.py` (auto) | Group of tables loaded by one pipeline run |
+| Lineage | `dlt_to_datahub.py` (auto) | We know the source and destination URNs at emit time |
+| Description | `dlt_to_datahub.py` (auto, default) | Falls back to `"Loaded by dlt pipeline <name>..."` if dlt has no description |
+| Tags | `dlt_to_datahub.py` (auto, default) | Every emitted dataset gets `dlt-ingested` so users can search "what came from dlt?" |
+| **Owners** | **UI (manual)** | Ownership is a human decision — who's accountable for this dataset |
+| **Domain** | **UI (manual)** | Business grouping (e.g. "Source Systems", "Marketing") — set by a steward, not a pipeline |
+| **Glossary terms** | **UI (manual)** | Maps columns to business concepts (`Customer Email`, `PII`) — needs business context |
+| **Documentation (long-form)** | UI (manual, optional) | Helper sets a one-line default; rich Markdown docs are added in the UI |
+
+**Why the split?** Auto-emitted metadata describes *what was loaded* — facts the pipeline knows. Manually-curated metadata describes *what the data means and who owns it* — judgements humans make. DataHub's value comes from holding both in one place.
+
+**To extend auto-emission**, edit `dlt_to_datahub.py`:
+```python
+# datahub.sdk.Dataset accepts these as constructor kwargs:
+ds = Dataset(
+    platform=...,
+    name=...,
+    owners=[CorpUserUrn("alice")],     # auto-set the pipeline owner
+    domain=DomainUrn("source-systems"),
+    terms=[GlossaryTermUrn("PII")],
+    ...
+)
+```
+Use sparingly — the more you auto-emit, the less of the "humans curate the catalog" story you can demo.
+
+---
+
+## How `dlt_to_datahub.py` uses the SDK
+
+The helper is a thin wrapper around DataHub's Python SDK v2 (`datahub.sdk.*`). The shape:
+
+```python
+from datahub.sdk.main_client import DataHubClient
+from datahub.sdk import Dataset, Container
+from datahub.emitter.mcp_builder import DatabaseKey
+
+client = DataHubClient(server="http://localhost:8080")
+
+# 1. Container per pipeline dataset
+container = Container(
+    container_key=DatabaseKey(platform="duckdb", database="github_data"),
+    display_name="github_data",
+    subtype="Database",
+)
+client.entities.upsert(container)
+
+# 2. Dataset per loaded table
+ds = Dataset(
+    platform="duckdb",
+    name="github_data.repos",
+    schema=[("id", "BIGINT"), ("name", "VARCHAR"), ...],
+    parent_container=container.urn,
+)
+client.entities.upsert(ds)
+
+# 3. Lineage from GitHub → DuckDB
+client.lineage.add_lineage(
+    upstream="urn:li:dataset:(urn:li:dataPlatform:github,dlt-hub/repos,PROD)",
+    downstream=ds.urn,
+)
+```
+
+Note: the SDK is marked `ExperimentalWarning`. The import path will move from `datahub.sdk.*` to `datahub.*` once it stabilises — `dlt_to_datahub.py` filters this warning so demo logs stay clean.
+
+---
+
+## Project layout
+
+```
+.
+├── README.md                 # this file
+├── requirements.txt          # dlt[duckdb] + acryl-datahub
+├── rest_api_pipeline.py      # dlt source + pipeline + DataHub emit call
+├── dlt_to_datahub.py         # local module wrapping datahub.sdk: integrate_dlt_pipeline_with_datahub, create_default_lineage_relationships
+├── .dlt/
+│   ├── config.toml
+│   └── secrets.toml          # GitHub PAT (gitignored)
+└── github_pipeline.duckdb    # created on first run
+```
+
+---
+
+## Troubleshooting
+
+**`datahub docker quickstart` hangs or fails on Mac (Apple Silicon)**
+Allocate ≥ 8 GB RAM in Docker Desktop. Run `datahub docker nuke` and retry.
+
+**`Connection refused` to `localhost:8080`**
+Wait — GMS takes ~60 s after `quickstart` returns before it's healthy. `curl localhost:8080/health` should print `GOOD`.
+
+**Pipeline runs but nothing shows up in DataHub**
+Check the `datahub_server` URL in `rest_api_pipeline.py` matches the GMS port (`8080`, not the UI `9002`). Look for `aspects emitted` lines in the run log.
+
+**GitHub 401 / 403**
+PAT is wrong or expired. Regenerate at https://github.com/settings/tokens and update `.dlt/secrets.toml`.
+
+**Schema not updating after re-run**
+dlt's `repos` resource uses `write_disposition="replace"` so schema changes are picked up. `issues` is `append` + incremental, so only new rows arrive — for a schema-evolution demo, run against `repos`.

--- a/datahub-demo/dlt_to_datahub.py
+++ b/datahub-demo/dlt_to_datahub.py
@@ -1,0 +1,168 @@
+"""Emit metadata from a dlt pipeline run to DataHub.
+
+Public API:
+    create_default_lineage_relationships(dataset_name) -> {table_name: upstream_urn}
+    integrate_dlt_pipeline_with_datahub(pipeline, ...) -> {"container": ..., "datasets": [...]}
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Dict, List, Optional, Tuple
+
+# The datahub.sdk module is marked experimental and emits a warning on import.
+# Suppress it so demo logs stay readable.
+warnings.filterwarnings("ignore", message=r".*datahub SDK.*")
+
+from datahub.emitter.mcp_builder import DatabaseKey
+from datahub.metadata.urns import DatasetUrn, TagUrn
+from datahub.sdk import Container, Dataset
+from datahub.sdk.main_client import DataHubClient
+
+# dlt creates these internal tables alongside user data; we register them in DataHub
+# under the same container so the picture is complete, but they're not "interesting".
+_DLT_INTERNAL_TABLES = {"_dlt_loads", "_dlt_pipeline_state", "_dlt_version"}
+
+# dlt -> SQL type names that DataHub's resolver recognises.
+_DLT_TO_SQL_TYPE = {
+    "text": "VARCHAR",
+    "bigint": "BIGINT",
+    "double": "DOUBLE",
+    "bool": "BOOLEAN",
+    "timestamp": "TIMESTAMP",
+    "date": "DATE",
+    "time": "TIME",
+    "decimal": "DECIMAL",
+    "json": "JSON",
+    "binary": "BLOB",
+    "wei": "VARCHAR",
+}
+
+
+def _columns_for_table(pipeline, table_name: str) -> List[Tuple[str, str]]:
+    schema = pipeline.default_schema
+    table = schema.tables.get(table_name)
+    if not table:
+        return []
+    fields: List[Tuple[str, str]] = []
+    for col_name, col in table.get("columns", {}).items():
+        sql_type = _DLT_TO_SQL_TYPE.get(col.get("data_type") or "text", "VARCHAR")
+        fields.append((col_name, sql_type))
+    return fields
+
+
+def create_default_lineage_relationships(dataset_name: str) -> Dict[str, str]:
+    """Return upstream-URN-by-table-name for the GitHub demo source.
+
+    The demo pulls from two GitHub REST endpoints, so we model each as an upstream
+    Dataset under the `github` platform. Edit this map when pointing the pipeline
+    at a different source.
+    """
+    _ = dataset_name  # unused for this hardcoded demo map; kept for API symmetry
+    return {
+        "repos": "urn:li:dataset:(urn:li:dataPlatform:github,dlt-hub/repos,PROD)",
+        "issues": "urn:li:dataset:(urn:li:dataPlatform:github,dlt-hub/dlt/issues,PROD)",
+    }
+
+
+def integrate_dlt_pipeline_with_datahub(
+    *,
+    pipeline,
+    platform_name: str = "dltHub",
+    datahub_server: str = "http://localhost:8080",
+    datahub_ui_url: str = "http://localhost:9002",
+    create_container: bool = True,
+    add_lineage: bool = True,
+    lineage_relationships: Optional[Dict[str, str]] = None,
+) -> dict:
+    """Emit a container, one Dataset per loaded table, and source→destination lineage.
+
+    Returns:
+        {
+            "container": {"urn": str, "url": str} | None,
+            "datasets": [str, ...],          # dataset URNs
+            "lineage_edges": [(upstream, downstream), ...],
+        }
+    """
+    _ = platform_name  # surfaced in container description; kept as an explicit knob
+
+    client = DataHubClient(server=datahub_server)
+    destination_platform = pipeline.destination.destination_name
+    dataset_name = pipeline.dataset_name
+
+    container = None
+    container_info = None
+    if create_container:
+        key = DatabaseKey(platform=destination_platform, database=dataset_name)
+        container = Container(
+            container_key=key,
+            display_name=dataset_name,
+            description=(
+                f"dlt pipeline `{pipeline.pipeline_name}` "
+                f"(orchestrator: {platform_name}, destination: {destination_platform})"
+            ),
+            subtype="Database",
+        )
+        client.entities.upsert(container)
+        container_urn = str(container.urn)
+        container_info = {
+            "urn": container_urn,
+            "url": f"{datahub_ui_url}/container/{container_urn}",
+        }
+
+    dataset_urns: List[str] = []
+    lineage_edges: List[Tuple[str, str]] = []
+
+    schema = pipeline.default_schema
+    for table_name, table_def in schema.tables.items():
+        if table_name in _DLT_INTERNAL_TABLES:
+            continue
+        columns = _columns_for_table(pipeline, table_name)
+        default_description = (
+            f"Loaded by dlt pipeline `{pipeline.pipeline_name}` "
+            f"into `{destination_platform}://{dataset_name}.{table_name}`."
+        )
+        ds = Dataset(
+            platform=destination_platform,
+            name=f"{dataset_name}.{table_name}",
+            schema=columns or None,
+            description=table_def.get("description") or default_description,
+            tags=[TagUrn("dlt-ingested")],
+            parent_container=container.urn if container is not None else None,
+        )
+        client.entities.upsert(ds)
+        dataset_urns.append(str(ds.urn))
+
+        if add_lineage:
+            parent = (table_def or {}).get("parent")
+            if parent:
+                # Child table (e.g. `repos__topics`) → parent table (`repos`)
+                # within the destination platform.
+                upstream = (
+                    f"urn:li:dataset:(urn:li:dataPlatform:{destination_platform},"
+                    f"{dataset_name}.{parent},PROD)"
+                )
+                client.lineage.add_lineage(upstream=upstream, downstream=ds.urn)
+                lineage_edges.append((upstream, str(ds.urn)))
+            elif lineage_relationships and table_name in lineage_relationships:
+                # Root table → external upstream (e.g. GitHub API endpoint).
+                # DataHub's UI hides lineage edges that point at "ghost" URNs
+                # (URNs with no entity behind them). Upsert a minimal Dataset
+                # for the upstream so the edge renders in the lineage graph.
+                upstream = lineage_relationships[table_name]
+                upstream_urn = DatasetUrn.from_string(upstream)
+                stub = Dataset(
+                    platform=upstream_urn.platform,
+                    name=upstream_urn.name,
+                    env=upstream_urn.env,
+                    description=f"Source for {table_name} (registered as a lineage stub).",
+                )
+                client.entities.upsert(stub)
+                client.lineage.add_lineage(upstream=upstream, downstream=ds.urn)
+                lineage_edges.append((upstream, str(ds.urn)))
+
+    return {
+        "container": container_info,
+        "datasets": dataset_urns,
+        "lineage_edges": lineage_edges,
+    }

--- a/datahub-demo/requirements.txt
+++ b/datahub-demo/requirements.txt
@@ -1,0 +1,2 @@
+dlt[duckdb]>=1.26.0
+acryl-datahub[datahub-rest]>=1.5.0

--- a/datahub-demo/rest_api_pipeline.py
+++ b/datahub-demo/rest_api_pipeline.py
@@ -1,0 +1,96 @@
+"""GitHub REST API → DuckDB pipeline, with metadata + lineage published to DataHub."""
+
+# mypy: disable-error-code="no-untyped-def,arg-type"
+
+from typing import Optional
+import dlt
+from dlt.sources.helpers.rest_client import RESTClient
+from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
+from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
+
+from dlt_to_datahub import (
+    create_default_lineage_relationships,
+    integrate_dlt_pipeline_with_datahub,
+)
+
+DLT_PLATFORM_NAME = "dltHub"
+DATAHUB_SERVER = "http://localhost:8080"
+DATAHUB_UI_URL = "http://localhost:9002"
+
+
+@dlt.source
+def github_source(access_token: Optional[str] = dlt.secrets.value):
+    # Optional auth: works with and without secrets
+    auth = BearerTokenAuth(token=access_token) if access_token else None
+
+    client = RESTClient(
+        base_url="https://api.github.com",
+        auth=auth,
+        paginator=HeaderLinkPaginator(),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    # Define a resource which fetches repos data
+    @dlt.resource(name="repos", write_disposition="replace")
+    def repos():
+        for page in client.paginate("orgs/dlt-hub/repos"):
+            yield page
+
+    # Define a resource which fetches issues data (incremental by updated_at timestamp)
+    @dlt.resource(name="issues", write_disposition="append")
+    def issues(
+        updated_at=dlt.sources.incremental(
+            "updated_at",
+            initial_value="2026-01-01T00:00:00Z",
+        )
+    ):
+        for page in client.paginate(
+            "repos/dlt-hub/dlt/issues",
+            params={
+                "state": "open",
+                "sort": "updated",
+                "direction": "desc",
+                "since": updated_at.start_value,
+                "per_page": "100",
+            },
+        ):
+            yield page
+
+    return [repos, issues]
+
+
+def run_source() -> None:
+    pipeline = dlt.pipeline(
+        pipeline_name="github_pipeline",
+        destination="duckdb",
+        dataset_name="github_data",
+        progress="log",
+    )
+
+    load_info = pipeline.run(github_source())
+    print(load_info)  # noqa: T201
+
+    lineage_relationships = create_default_lineage_relationships(pipeline.dataset_name)
+
+    result = integrate_dlt_pipeline_with_datahub(
+        pipeline=pipeline,
+        platform_name=DLT_PLATFORM_NAME,
+        datahub_server=DATAHUB_SERVER,
+        datahub_ui_url=DATAHUB_UI_URL,
+        create_container=True,
+        add_lineage=True,
+        lineage_relationships=lineage_relationships,
+    )
+
+    print(f"\nEmitted {len(result['datasets'])} datasets to DataHub.")  # noqa: T201
+    if result["container"]:
+        print(f"Container: {result['container']['url']}")  # noqa: T201
+    for upstream, downstream in result["lineage_edges"]:
+        print(f"Lineage: {upstream}  ->  {downstream}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    run_source()


### PR DESCRIPTION
Demonstrates publishing dlt pipeline datasets, schemas, and lineage to a local DataHub instance using a GitHub REST API source.